### PR TITLE
Fix bug where its pushing, instead of emitting an error

### DIFF
--- a/readableStreamClone.js
+++ b/readableStreamClone.js
@@ -14,7 +14,7 @@ var ReadableStream = function(readableStream, options) {
     });
 
     readableStream.on("error", function(err) {
-        me.emit(err);
+        me.destroy(err);
     });
     me._read = function() {
     };

--- a/readableStreamClone.js
+++ b/readableStreamClone.js
@@ -14,7 +14,7 @@ var ReadableStream = function(readableStream, options) {
     });
 
     readableStream.on("error", function(err) {
-        me.push(err);
+        me.emit(err);
     });
     me._read = function() {
     };

--- a/readableStreamClone.js
+++ b/readableStreamClone.js
@@ -14,7 +14,7 @@ var ReadableStream = function(readableStream, options) {
     });
 
     readableStream.on("error", function(err) {
-        me.destroy(err);
+        me.emit("error", err);
     });
     me._read = function() {
     };


### PR DESCRIPTION
This useful little utility has a problem - if it receives an error then it tries to push an error , which of course fails (you can't push an object on readable-streams). 
Instead it should `emit` the error which has the expected effect.
Note that this error has to be handled on each of the clones as they'll all get the error, but that turns out to be the behavior wanted anyway as each clone may handle it differently.